### PR TITLE
Remove deprecated sudo setting.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,5 @@
 language: java
 
-sudo: false
-
 jdk:
   - oraclejdk8
 


### PR DESCRIPTION
[Travis are now recommending removing the sudo tag.](https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration)